### PR TITLE
FLINK-25963 Experiment with async Reconciliation

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -21,9 +21,11 @@ import org.apache.flink.kubernetes.operator.config.DefaultConfig;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.controller.FlinkControllerConfig;
 import org.apache.flink.kubernetes.operator.controller.FlinkDeploymentController;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.metrics.OperatorMetricUtils;
 import org.apache.flink.kubernetes.operator.observer.Observer;
 import org.apache.flink.kubernetes.operator.reconciler.ReconcilerFactory;
+import org.apache.flink.kubernetes.operator.reconciler.caching.CachingReconciler;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.validation.DefaultDeploymentValidator;
@@ -31,6 +33,7 @@ import org.apache.flink.kubernetes.operator.validation.FlinkDeploymentValidator;
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.config.runtime.DefaultConfigurationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,7 +81,9 @@ public class FlinkOperator {
         controller.setControllerConfig(controllerConfig);
         controllerConfig.setConfigurationService(configurationService);
 
-        operator.register(controller, controllerConfig);
+        Reconciler<FlinkDeployment> cachingReconciler = new CachingReconciler<>(controller);
+
+        operator.register(cachingReconciler, controllerConfig);
         operator.installShutdownHook();
         operator.start();
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkDeploymentSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkDeploymentSpec.java
@@ -23,6 +23,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.util.Map;
 
 /** Spec that describes a Flink application deployment. */
@@ -30,7 +31,7 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class FlinkDeploymentSpec {
+public class FlinkDeploymentSpec implements Serializable {
     private String image;
     private String imagePullPolicy;
     private String serviceAccount;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobManagerSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobManagerSpec.java
@@ -22,11 +22,13 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 /** JobManager spec. */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class JobManagerSpec {
+public class JobManagerSpec implements Serializable {
     private Resource resource;
     private int replicas;
     private Pod podTemplate;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobSpec.java
@@ -23,12 +23,14 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 /** Flink job spec. */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class JobSpec {
+public class JobSpec implements Serializable {
     private String jarURI;
     private int parallelism;
     private String entryClass;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/Resource.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/Resource.java
@@ -21,11 +21,13 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 /** Resource spec. */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class Resource {
+public class Resource implements Serializable {
     private double cpu;
     // 1024m, 1g
     private String memory;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/TaskManagerSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/TaskManagerSpec.java
@@ -22,11 +22,13 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 /** TaskManager spec. */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class TaskManagerSpec {
+public class TaskManagerSpec implements Serializable {
     private Resource resource;
     private Pod podTemplate;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/FlinkDeploymentStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/FlinkDeploymentStatus.java
@@ -23,11 +23,13 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 /** Current status of the Flink deployment. */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class FlinkDeploymentStatus {
+public class FlinkDeploymentStatus implements Serializable {
     private JobStatus jobStatus = new JobStatus();
     private JobManagerDeploymentStatus jobManagerDeploymentStatus =
             JobManagerDeploymentStatus.MISSING;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/JobStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/JobStatus.java
@@ -22,12 +22,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 /** Status of an individual job within the Flink deployment. */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class JobStatus {
+public class JobStatus implements Serializable {
     private String jobName;
     private String jobId;
     private String state;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationStatus.java
@@ -24,12 +24,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 /** Status of the Flink deployment reconciliation flow. */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ReconciliationStatus {
+public class ReconciliationStatus implements Serializable {
     private boolean success;
     private String error;
     private FlinkDeploymentSpec lastReconciledSpec;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/Cache.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/Cache.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.reconciler.caching;
+
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Cache for storing reconciliation results. */
+public class Cache<R> {
+    // TODO: implement cache invalidation
+
+    private final ConcurrentHashMap<ResourceID, CacheEntry<R>> store = new ConcurrentHashMap<>();
+
+    public CacheEntry<R> get(ResourceID id) {
+        return store.computeIfAbsent(id, id0 -> CacheEntry.emptyEntryFor(id));
+    }
+
+    public CacheEntry<R> put(ResourceID id, CacheEntry<R> entry) {
+        return store.put(id, entry);
+    }
+
+    /** An entry in the cache. */
+    @Data
+    @AllArgsConstructor
+    public static final class CacheEntry<R> {
+        public final ResourceID id;
+        public final Optional<R> value; // TODO: that value is not really used for anything
+        public final Optional<ReconcileResult> pendingResult;
+        public final boolean asyncRunning;
+
+        public CacheEntry<R> withValue(R value) {
+            return new CacheEntry(id, Optional.of(value), pendingResult, asyncRunning);
+        }
+
+        public CacheEntry<R> withPendingResult(ReconcileResult pendingResult) {
+            return new CacheEntry(id, value, Optional.of(pendingResult), asyncRunning);
+        }
+
+        public CacheEntry<R> withAsyncRunning(boolean asyncRunning) {
+            return new CacheEntry(id, value, pendingResult, asyncRunning);
+        }
+
+        public CacheEntry<R> withEmptyPendingResult() {
+            return new CacheEntry(id, value, Optional.empty(), asyncRunning);
+        }
+
+        public static <R> CacheEntry<R> emptyEntryFor(ResourceID id) {
+            return new CacheEntry<R>(id, Optional.empty(), Optional.empty(), false);
+        }
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/CachingReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/CachingReconciler.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.reconciler.caching;
+
+import org.apache.flink.kubernetes.operator.reconciler.caching.Cache.CacheEntry;
+import org.apache.flink.kubernetes.operator.utils.SerializationUtils;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
+import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusHandler;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceInitializer;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static org.apache.flink.kubernetes.operator.reconciler.caching.SupplierSupport.withErrorHandler;
+
+/** Caching reconciler. */
+public class CachingReconciler<
+                S,
+                T,
+                R extends CustomResource<S, T>,
+                E extends Reconciler<R> & ErrorStatusHandler<R> & EventSourceInitializer<R>>
+        implements Reconciler<R>, ErrorStatusHandler<R>, EventSourceInitializer<R> {
+
+    private final E wrappedReconciler;
+
+    private final Cache<R> cache = new Cache<>();
+
+    public CachingReconciler(E wrappedReconciler) {
+        this.wrappedReconciler = wrappedReconciler;
+    }
+
+    @Override
+    public UpdateControl<R> reconcile(R resource, Context context) {
+        ResourceID resourceId = ResourceID.fromResource(resource);
+
+        CacheEntry<R> entry = cache.get(resourceId);
+
+        if (entry.getPendingResult().isPresent()) {
+            return processPendingResult(resource, entry);
+        }
+
+        if (entry.asyncRunning) {
+            // Already in progress
+            return UpdateControl.noUpdate();
+        }
+
+        MemoryVisibilitySupport.sync(resourceId);
+
+        final R copiedRes = SerializationUtils.deepCopy(resource);
+
+        Supplier<UpdateControl<R>> reconcileCall =
+                withErrorHandler(
+                        () -> {
+                            // It is only to enforce that the thread running here sees
+                            // everything that was visible for the thread executing
+                            // CachingReconciler::reconcile
+                            MemoryVisibilitySupport.sync(resourceId);
+
+                            // TODO: `context` might not be ThreadSafe or usable after sync return
+                            return wrappedReconciler.reconcile(copiedRes, context);
+                        });
+
+        Consumer<UpdateControl<R>> asyncHandlerSuccess =
+                updateControl -> {
+                    cache.put(
+                            resourceId,
+                            entry.withPendingResult(new ReconcileResult(copiedRes, updateControl))
+                                    .withValue(copiedRes)
+                                    .withAsyncRunning(false));
+                    triggerReconcileAgain(resourceId);
+                };
+
+        Consumer<Exception> asyncHandlerFailure =
+                exception -> {
+                    cache.put(resourceId, entry.withAsyncRunning(false));
+                    triggerReconcileAgain(resourceId);
+                };
+
+        int gracePeriodMillis = 500; // TODO: from config
+        Optional<UpdateControl<R>> syncResult =
+                SyncOrAsyncExecutor.runSyncOrAsync(
+                        reconcileCall, gracePeriodMillis, asyncHandlerSuccess, asyncHandlerFailure);
+
+        if (syncResult.isPresent()) {
+            return syncResult.get();
+        }
+
+        cache.put(resourceId, entry.withAsyncRunning(true));
+        return UpdateControl.noUpdate();
+    }
+
+    private UpdateControl<R> processPendingResult(R resource, CacheEntry<R> entry) {
+        ResourceID resourceId = entry.getId();
+        ReconcileResult<S, T, R> result = entry.pendingResult.get();
+        cache.put(resourceId, entry.withEmptyPendingResult());
+        if (hasSameVersion(resource, result.resource)) {
+            resource.setSpec(result.resource.getSpec());
+            resource.setStatus(result.resource.getStatus());
+            return result.updateControl;
+        } else {
+            // Resource was updated during async reconciliation
+            triggerReconcileAgain(resourceId);
+            return UpdateControl.noUpdate();
+        }
+    }
+
+    private boolean hasSameVersion(R a, R b) {
+        String aVersion = a.getMetadata().getResourceVersion();
+        String bVersion = b.getMetadata().getResourceVersion();
+        return Objects.equals(aVersion, bVersion);
+    }
+
+    @Override
+    public DeleteControl cleanup(R resource, Context context) {
+        // TODO: async cleanup
+        return wrappedReconciler.cleanup(resource, context);
+    }
+
+    @Override
+    public Optional<R> updateErrorStatus(R resource, RetryInfo retryInfo, RuntimeException e) {
+        return wrappedReconciler.updateErrorStatus(resource, retryInfo, e);
+    }
+
+    @Override
+    public List<EventSource> prepareEventSources(EventSourceContext<R> context) {
+        List<EventSource> all = new LinkedList<>(wrappedReconciler.prepareEventSources(context));
+        all.add(trigger);
+        return all;
+    }
+
+    private final ReconcileTrigger trigger = new ReconcileTrigger();
+
+    private void triggerReconcileAgain(ResourceID id) {
+        trigger.fire(id);
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/MemoryVisibilitySupport.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/MemoryVisibilitySupport.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.reconciler.caching;
+
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Utility class for thread interoperability. */
+public class MemoryVisibilitySupport {
+    // TODO: implement cleanup
+    private static final ConcurrentHashMap<ResourceID, Object> locks = new ConcurrentHashMap<>();
+
+    public static void sync(ResourceID id) {
+        synchronized (locks.computeIfAbsent(id, id0 -> new Object())) {
+            // This is just a memory barrier
+            assert true;
+        }
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/ReconcileResult.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/ReconcileResult.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.reconciler.caching;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/** Result of a Reconciler#reconcile call. */
+@Data
+@AllArgsConstructor
+public class ReconcileResult<S, T, R extends CustomResource<S, T>> {
+    public final R resource;
+    public final UpdateControl<R> updateControl;
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/ReconcileTrigger.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/ReconcileTrigger.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.reconciler.caching;
+
+import io.javaoperatorsdk.operator.OperatorException;
+import io.javaoperatorsdk.operator.processing.event.Event;
+import io.javaoperatorsdk.operator.processing.event.EventHandler;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+
+/** Event source for triggering reconcile from CachingReconciler. */
+public class ReconcileTrigger implements EventSource {
+
+    // TODO: Check if EventSource is supposed to be used that way
+    private EventHandler handler =
+            (Event event) -> new RuntimeException("ReconcileTrigger handle not initialized");
+
+    @Override
+    public void setEventHandler(EventHandler handler) {
+        this.handler = handler;
+    }
+
+    public void fire(ResourceID id) {
+        handler.handleEvent(new Event(id));
+    }
+
+    @Override
+    public void start() throws OperatorException {}
+
+    @Override
+    public void stop() throws OperatorException {}
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/RunnableSupport.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/RunnableSupport.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.reconciler.caching;
+
+/** Utility methods for the Runnable interface. */
+public class RunnableSupport {
+    public static Runnable withErrorHandler(PossiblyFailingCode r) {
+        return () -> {
+            try {
+                r.run();
+            } catch (Throwable t) {
+                // TODO proper error handling, logging
+                t.printStackTrace(System.err);
+                throw new RuntimeException(t);
+            }
+        };
+    }
+
+    /** A Runnable that might throw an Exception. */
+    @FunctionalInterface
+    public interface PossiblyFailingCode {
+        void run() throws Exception;
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/SupplierSupport.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/SupplierSupport.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.reconciler.caching;
+
+import java.util.function.Supplier;
+
+/** Utility methods for the Supplier interface. */
+public class SupplierSupport {
+    public static <T> Supplier<T> withErrorHandler(PossiblyFailingSupplier<T> supplier) {
+        return () -> {
+            try {
+                return supplier.get();
+            } catch (Throwable t) {
+                // TODO proper error handling, logging
+                t.printStackTrace(System.err);
+                throw new RuntimeException(t);
+            }
+        };
+    }
+
+    /** A Supplier that might throw an Exception. */
+    @FunctionalInterface
+    public interface PossiblyFailingSupplier<T> {
+        T get() throws Exception;
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/SyncOrAsyncExecutor.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/caching/SyncOrAsyncExecutor.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.reconciler.caching;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static org.apache.flink.kubernetes.operator.reconciler.caching.RunnableSupport.withErrorHandler;
+import static org.apache.flink.kubernetes.operator.reconciler.caching.SyncOrAsyncExecutor.ExecutionState.COMPUTED_IN_TIME;
+import static org.apache.flink.kubernetes.operator.reconciler.caching.SyncOrAsyncExecutor.ExecutionState.FAILED_IN_TIME;
+import static org.apache.flink.kubernetes.operator.reconciler.caching.SyncOrAsyncExecutor.ExecutionState.GRACE_PERIOD_OVER;
+import static org.apache.flink.kubernetes.operator.reconciler.caching.SyncOrAsyncExecutor.ExecutionState.INITIALIZED;
+
+/**
+ * An executor, that tries to execute an operation within a grace period. If the operation returns
+ * within the grace period, the result is synchronously returned.
+ *
+ * <p>If the grace period elapses without the operation returning, it keeps executing the operation
+ * in the background while returns with an empty result synchronously.
+ *
+ * <p>The results of the async operation could be processed by callbacks.
+ */
+public class SyncOrAsyncExecutor {
+
+    private static final ExecutorService es = Executors.newCachedThreadPool();
+
+    /** INITIALIZED is the start state, all the other states are end states. */
+    enum ExecutionState {
+        INITIALIZED,
+        COMPUTED_IN_TIME,
+        FAILED_IN_TIME,
+        GRACE_PERIOD_OVER
+    }
+
+    @Data
+    @AllArgsConstructor
+    private static class SharedStore<T> {
+        public final ExecutionState executionState;
+        public final Optional<T> result;
+        public final Optional<Exception> failure;
+
+        public SharedStore<T> withExecutionState(ExecutionState executionState) {
+            return new SharedStore<>(executionState, result, failure);
+        }
+
+        public SharedStore<T> withResult(T result) {
+            // TODO: The value returned from Supplier.get will be stored in the result field,
+            // although Optional.of does not support storing null values
+            return new SharedStore<>(executionState, Optional.of(result), failure);
+        }
+
+        public SharedStore<T> withFailure(Exception e) {
+            return new SharedStore<>(executionState, result, Optional.of(e));
+        }
+
+        public static <T> SharedStore<T> init() {
+            return new SharedStore<>(INITIALIZED, Optional.empty(), Optional.empty());
+        }
+    }
+
+    public static <T> Optional<T> runSyncOrAsync(
+            Supplier<T> operation,
+            long gracePeriodMillis,
+            Consumer<T> successCallback,
+            Consumer<Exception> failureCallback) {
+
+        AtomicReference<SharedStore<T>> atomicStore = new AtomicReference<>(SharedStore.init());
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // TODO: refactor to minimise code nesting
+        es.execute(
+                withErrorHandler(
+                        () -> {
+                            try {
+                                T result = operation.get();
+                                atomicStore.updateAndGet(
+                                        st -> {
+                                            switch (st.executionState) {
+                                                case INITIALIZED:
+                                                    return st.withResult(result)
+                                                            .withExecutionState(COMPUTED_IN_TIME);
+                                                case GRACE_PERIOD_OVER:
+                                                    successCallback.accept(result);
+                                                    return st;
+                                                default:
+                                                    throw exceptionWithUnexpectedState(
+                                                            st.executionState);
+                                            }
+                                        });
+                            } catch (Exception e) {
+                                atomicStore.updateAndGet(
+                                        st -> {
+                                            switch (st.executionState) {
+                                                case INITIALIZED:
+                                                    return st.withFailure(e)
+                                                            .withExecutionState(FAILED_IN_TIME);
+                                                case GRACE_PERIOD_OVER:
+                                                    failureCallback.accept(e);
+                                                    return st;
+                                                default:
+                                                    throw exceptionWithUnexpectedState(
+                                                            st.executionState);
+                                            }
+                                        });
+                            } finally {
+                                latch.countDown();
+                            }
+                        }));
+        es.execute(
+                withErrorHandler(
+                        () -> {
+                            Thread.sleep(gracePeriodMillis);
+                            atomicStore.updateAndGet(
+                                    st -> {
+                                        switch (st.executionState) {
+                                            case INITIALIZED:
+                                                return st.withExecutionState(GRACE_PERIOD_OVER);
+                                            case COMPUTED_IN_TIME:
+                                            case FAILED_IN_TIME:
+                                                return st; // nothing to do
+                                            default:
+                                                throw exceptionWithUnexpectedState(
+                                                        st.executionState);
+                                        }
+                                    });
+                            latch.countDown();
+                        }));
+        await(latch);
+
+        SharedStore<T> store = atomicStore.get();
+        switch (store.executionState) {
+            case COMPUTED_IN_TIME:
+                return Optional.of(store.result.get());
+            case FAILED_IN_TIME:
+                throw new RuntimeException(store.failure.get());
+            case GRACE_PERIOD_OVER:
+                return Optional.empty();
+            default:
+                throw exceptionWithUnexpectedState(store.executionState);
+        }
+    }
+
+    private static RuntimeException exceptionWithUnexpectedState(ExecutionState executionState) {
+        return new RuntimeException(
+                String.format("Unexpected execution state: %s", executionState));
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SerializationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SerializationUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/** Serialization-related utilities. */
+public class SerializationUtils {
+    public static <T extends Serializable> T deepCopy(T obj) {
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(bos); ) {
+            oos.writeObject(obj);
+            oos.flush();
+            try (ByteArrayInputStream bin = new ByteArrayInputStream(bos.toByteArray());
+                    ObjectInputStream ois = new ObjectInputStream(bin); ) {
+                return (T) ois.readObject();
+            }
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
This is an experiment to see how async reconciliation could be implemented.

The CachingReconciler tries to execute reconciliation within a grace period synchronously, but if it takes too long, it simply returns with no updates and keeps the reconciliation running in the background.

This is very much work-in-progress, not tested at all, just trying to demonstrate the concept.